### PR TITLE
chore: removed deprecation message as has been long enough now

### DIFF
--- a/lib/webhook.js
+++ b/lib/webhook.js
@@ -1,7 +1,6 @@
 const MessageBuilder = require("./builder");
 
 const snekfetch = require("snekfetch");
-const util = require("util");
 
 const ENDPOINT = "https://discordapp.com/api/v7/webhooks";
 
@@ -314,8 +313,6 @@ class Webhook {
         });
     }
 }
-
-Webhook.prototype.custom = util.deprecate(Webhook.prototype.custom, "Custom is deprecated, use MessageBuilder instead");
 
 module.exports = {
     Webhook,


### PR DESCRIPTION
No need for this annoying deprecation message. `util` isn't installed properly anyway, and it stops it working in the browser.

Many Thanks